### PR TITLE
Add support for SnapHelpers that display multiple items after a snap event

### DIFF
--- a/CircleIndicator.iml
+++ b/CircleIndicator.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="CircleIndicator" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="CircleIndicator" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>

--- a/circleindicator/src/main/java/me/relex/circleindicator/SimpleSnapIndexController.java
+++ b/circleindicator/src/main/java/me/relex/circleindicator/SimpleSnapIndexController.java
@@ -1,0 +1,35 @@
+package me.relex.circleindicator;
+
+import android.view.View;
+
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.SnapHelper;
+
+class SimpleSnapIndexController implements SnapIndexController {
+
+    private final RecyclerView mRecyclerView;
+    private final SnapHelper mSnapHelper;
+
+    public SimpleSnapIndexController(RecyclerView recyclerView, SnapHelper snapHelper) {
+        mRecyclerView = recyclerView;
+        mSnapHelper = snapHelper;
+    }
+
+    @Override
+    public int getSnappedIndex() {
+        RecyclerView.LayoutManager layoutManager = mRecyclerView.getLayoutManager();
+        if (layoutManager == null) return RecyclerView.NO_POSITION;
+
+        final View snapView = mSnapHelper.findSnapView(layoutManager);
+        if (snapView == null) return RecyclerView.NO_POSITION;
+
+        return layoutManager.getPosition(snapView);
+    }
+
+    @Override
+    public int getTotalIndicatorCount() {
+        final RecyclerView.Adapter adapter = mRecyclerView.getAdapter();
+        if (adapter == null) return 0;
+        return adapter.getItemCount();
+    }
+}

--- a/circleindicator/src/main/java/me/relex/circleindicator/SnapIndexController.java
+++ b/circleindicator/src/main/java/me/relex/circleindicator/SnapIndexController.java
@@ -1,6 +1,6 @@
 package me.relex.circleindicator;
 
-interface SnapIndexController {
+public interface SnapIndexController {
     int getSnappedIndex();
     int getTotalIndicatorCount();
 }

--- a/circleindicator/src/main/java/me/relex/circleindicator/SnapIndexController.java
+++ b/circleindicator/src/main/java/me/relex/circleindicator/SnapIndexController.java
@@ -1,0 +1,6 @@
+package me.relex.circleindicator;
+
+interface SnapIndexController {
+    int getSnappedIndex();
+    int getTotalIndicatorCount();
+}


### PR DESCRIPTION
CircleIndicator2 works fine with SnapHelpers like PagerSnapHelper since they only show a single recycler view item after a snap event. But it's not possible to use it with SnapHelpers such as SnapToBlock SnapHelper because they don't have one to one relationship between items and indicators. [SnapToBlock SnapHelper](https://stackoverflow.com/a/47580753/6644987) 
So in this pull request, I created SnapIndexController interface to abstract out SnapHelper, indicator index and item count relationship.

- Create SnapIndexController interface
- Delegate all calls that related to indicator index and indicator count to SnapIndexController in CircleIndicator2 class.
- Create SimpleSnapIndexController class for SnapHelpers that shows a single item on a single page.
- Add an overloading attachToRecyclerView method to CircleIndicator2
